### PR TITLE
implements paper-select event firing

### DIFF
--- a/paper-drawer-panel.html
+++ b/paper-drawer-panel.html
@@ -300,7 +300,8 @@ To change the drawer container when it's in the right side:
         selected: {
           reflectToAttribute: true,
           type: String,
-          value: null
+          value: null,
+          notify: true
         },
 
         /**
@@ -353,6 +354,7 @@ To change the drawer container when it's in the right side:
        */
       openDrawer: function() {
         this.selected = 'drawer';
+        this.fire('paper-select', {isSelected: this._isMainSelected() ? false : true, item: this});
       },
 
       /**
@@ -362,6 +364,7 @@ To change the drawer container when it's in the right side:
        */
       closeDrawer: function() {
         this.selected = 'main';
+        this.fire('paper-select', {isSelected: this._isMainSelected() ? false : true, item: this});
       },
 
       ready: function() {


### PR DESCRIPTION
* Fired when the selected panel changes.
*
* Listening for this event is an alternative to observing changes in the `selected` attribute.
* This event is fired both when a panel is selected and deselected.
* The `isSelected` detail property contains the selection state.
*
* @event paper-select {{isSelected: boolean, item: Object}} detail -
*     isSelected: True for selection and false for deselection.
*     item: The panel that the event refers to.